### PR TITLE
🔧 build: update maven-compiler-plugin to build with more modern JDK (17)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
     <url>https://github.com/wiztools/javadoc-jar-viewer</url>
     
     <properties>
+        <jdk.version>17</jdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     
@@ -22,10 +23,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.12.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <release>${jdk.version}</release>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Instead of targeting Java 1.6, parameterize the JDK version, set it to 17.